### PR TITLE
Use shivammathur/setup-php@v2 to set PHP Version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Set up PHP Version
-        run: |
-          sudo update-alternatives --set php /usr/bin/php7.3
-          php -v
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.3
 
       - name: Start MySQL
         run: sudo /etc/init.d/mysql start


### PR DESCRIPTION
I always use the shivammathur/setup-php@v2 for PHP Versions etc. It makes it really easy to require the versions needed.

I know this is a demo project, but would still go with standards when possible. 