### PR TITLE
Use shivammathur/setup-php@v2 for composer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,10 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 7.3
-
+          tools: composer:v2
+          
       - name: Start MySQL
         run: sudo /etc/init.d/mysql start
-
-      - name: Update Composer
-        run: |
-          sudo composer self-update
-          composer --version
 
       # Directory permissions for .composer are wrong, so we remove the complete directory
       # https://github.com/actions/virtual-environments/issues/824


### PR DESCRIPTION
I didn't pay attention to this in morning. 
But the composer self-update can bare spared, as the shivammathur/setup-php@v2 also have the option so say with composer version. 

As you are doing a self-update already I would expect you to be happy with the composer v2 in your setup. 